### PR TITLE
Show git checkout log

### DIFF
--- a/src/get-modified-files/switch-to-branch.js
+++ b/src/get-modified-files/switch-to-branch.js
@@ -5,7 +5,7 @@ const switchToBranch = (branch = 'master') => {
     shell
       .exec(`git checkout ${branch}`, {
         async: true,
-        silent: true,
+        silent: false,
       })
       .on('exit', handleException);
     function handleException(code) {


### PR DESCRIPTION
The default error: "cannot swich to <BRANCH_NAME>" is not informative and cannot be traced.