### PR TITLE
Nissix plugin scope-packages on sync-ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "lint-staged": "^10.0.7",
     "mock-fs": "^4.11.0",
     "shelljs": "^0.8.3",
-    "yoshi": "^4.0.0"
+    "@wix/yoshi": "^4.0.0"
   },
   "jest": {
     "testPathIgnorePatterns": [

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,5 +1,5 @@
 module.exports = function(wallaby) {
-  return Object.assign({}, require('yoshi/config/wallaby-jest')(wallaby), {
+  return Object.assign({}, require('@wix/yoshi/config/wallaby-jest')(wallaby), {
     // set to undefined to let Wallaby decide the number of processes based on the system's capacity
     workers: undefined,
   });


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 6.599s



Output Log:
Migrating package "sync-ts" in .


## Migration from non scope to @wix/scoped packages
> /tmp/92b3fda9fec5dc9d83ba825f5655ef44

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
wallaby.js
```

